### PR TITLE
Fix line close

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alexflint/go-arg"
+	arg "github.com/alexflint/go-arg"
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"github.com/peterh/liner"
 	"github.com/thecodeteam/goodbye"
@@ -125,6 +125,7 @@ func run() error {
 	defer goodbye.Exit(ctx, -1)
 	goodbye.Notify(ctx)
 	goodbye.Register(func(ctx context.Context, sig os.Signal) {
+		line.Close()
 		writeHistoryFile(line)
 	})
 


### PR DESCRIPTION
When exiting abacus my shell is broken. Entered characters are not displayed and after hitting return the line just stays empty and adds another input prompt at the end. I'm having bash 5.0.17.

The `line.Close()` does not seem to get evalated correctly. If I add it into the the `goodbye.Regsiter` call the problem disappears. You may probably have a better fix for that. Please review. Thanks.

Sorry about the changing import line. My go linter does this automatically.